### PR TITLE
parse inline tags as block

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ var inlineTags = require('./lib/inline-tags');
 
 module.exports = parse;
 module.exports.Parser = Parser;
-function parse(tokens, filename, options) {
+function parse(tokens, filename, options, inlineAsBlock) {
+  inlineTags = (inlineAsBlock === true) ? [] : inlineTags;
   var parser = new Parser(tokens, filename, options);
   var ast = parser.parse();
   return JSON.parse(JSON.stringify(ast));


### PR DESCRIPTION
is it possible to add an option that can be controlled manually, as "pretty" option, to be able to render inline elements as block?

my suggestion:
```
{
  "inlineAsBlock": true | false | undefined
}
```

for example:
"inlineAsBlock": false or undefined --- will not affect and render like this ▼
```
<ul>
	<li><a href="same.html">Lorem ipsum dolor.</a> <strong>maxime, dolores.</<strong></li>
</ul>
```

and "inlineAsBlock": true --- will render like this ▼
```
<ul>
	<li>
		<a href="same.html">Lorem ipsum dolor.</a>
		<strong>maxime, dolores.</<strong>
	</li>
</ul>
```


changes are also needed in
[pug/lib/index.js](https://github.com/pugjs/pug/blob/master/lib/index.js)