### PR TITLE
Support the legacy `.jade` extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -789,8 +789,14 @@ loop:
 
     node.file.path = path.val.trim();
 
-    if (/\.pug$/.test(node.file.path) && !filters.length) {
+    if ((/\.jade$/.test(node.file.path) || /\.pug$/.test(node.file.path)) && !filters.length) {
       node.block = 'indent' == this.peek().type ? this.block() : this.emptyBlock(tok.line);
+      if (/\.jade$/.test(node.file.path)) {
+        console.warn(
+          this.filename + ', line ' + tok.line +
+          ':\nThe .jade extension is deprecated, use .pug for "' + node.file.path +'".'
+        );
+      }
     } else {
       node.type = 'RawInclude';
       node.filters = filters;


### PR DESCRIPTION
This is a breaking change, so we should release it as pug-parser 2.0.0 but can release as a new alpha of pug.